### PR TITLE
Fix use-after-free in text input default value handling

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -13,6 +13,18 @@ fn main() {
         None => user_input = "null".to_string(),
     }
 
+    let user_input_2: String;
+    match tinyfiledialogs::input_box("Re-enter user name", "Username:", &user_input) {
+        Some(input) => user_input_2 = input,
+        None => user_input_2 = "null".to_string(),
+    }
+
+    let password_input: String;
+    match tinyfiledialogs::password_box("Enter password", "Password:") {
+        Some(input) => password_input = input,
+        None => password_input = "null".to_string(),
+    }
+
     let save_file: String;
     match tinyfiledialogs::save_file_dialog("Save", "password.txt") {
         Some(file) => save_file = file,
@@ -49,6 +61,8 @@ fn main() {
 
     println!("Choice {:?}", choice);
     println!("User input {:?}", user_input);
+    println!("User input 2 {:?}", user_input_2);
+    println!("Password input {:?}", password_input);
     println!("Save file {:?}", save_file);
     println!("Open file {:?}", open_file);
     println!("folder {:?}", folder);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ fn input_box_impl(title: &str, message: &str, default: Option<&str>) -> Option<S
     let c_input = unsafe {
         tinyfd_inputBox(input_box_title.as_ptr(),
                         input_box_message.as_ptr(),
-                        input_box_default.map(|d| d.as_ptr()).unwrap_or(ptr::null()))
+                        input_box_default.as_ref().map(|d| d.as_ptr()).unwrap_or(ptr::null()))
     };
 
     if !c_input.is_null() {


### PR DESCRIPTION
As [others have noted](https://users.rust-lang.org/t/cstring-as-ptr-is-incredibly-unsafe/11431), `as_ptr()` is quite the footgun. In this case it leads to the default value for text inputs to point to invalid memory. At least with Zenity on Linux, the result is that the default value is simply ignored.