### PR TITLE
Switched to UTF-8 encoding on Windows

### DIFF
--- a/libtinyfiledialogs/tinyfiledialogs.c
+++ b/libtinyfiledialogs/tinyfiledialogs.c
@@ -117,7 +117,7 @@ misrepresented as being the original software.
  #include <commdlg.h>
  #define TINYFD_NOCCSUNICODE
  #define SLASH "\\"
- int tinyfd_winUtf8 = 0 ; /* on windows string char can be 0:MBCS or 1:UTF-8 */
+ int tinyfd_winUtf8 = 1 ; /* on windows string char can be 0:MBCS or 1:UTF-8 */
 #else
  #include <limits.h>
  #include <unistd.h>

--- a/patches/0001_WinUtf8.patch
+++ b/patches/0001_WinUtf8.patch
@@ -1,0 +1,13 @@
+diff --git a/libtinyfiledialogs/tinyfiledialogs.c b/libtinyfiledialogs/tinyfiledialogs.c
+index 7e6a3b5..3bc9f8a 100644
+--- a/libtinyfiledialogs/tinyfiledialogs.c
++++ b/libtinyfiledialogs/tinyfiledialogs.c
+@@ -117,7 +117,7 @@ misrepresented as being the original software.
+  #include <commdlg.h>
+  #define TINYFD_NOCCSUNICODE
+  #define SLASH "\\"
+- int tinyfd_winUtf8 = 0 ; /* on windows string char can be 0:MBCS or 1:UTF-8 */
++ int tinyfd_winUtf8 = 1 ; /* on windows string char can be 0:MBCS or 1:UTF-8 */
+ #else
+  #include <limits.h>
+  #include <unistd.h>

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,12 @@
-wget https://sourceforge.net/projects/tinyfiledialogs/files/tinyfiledialogs.h/download -O tinyfiledialogs.h
-tr -d '\r' < tinyfiledialogs.h > libtinyfiledialogs/tinyfiledialogs.h
-wget https://sourceforge.net/projects/tinyfiledialogs/files/tinyfiledialogs.c/download -O tinyfiledialogs.c
-tr -d '\r' < tinyfiledialogs.c > libtinyfiledialogs/tinyfiledialogs.c
+#!/bin/sh
+set -eux
+
+for ext in h c
+do
+	wget "https://sourceforge.net/projects/tinyfiledialogs/files/tinyfiledialogs.${ext}/download" -O - | tr -d '\r' > libtinyfiledialogs/tinyfiledialogs.${ext}
+done
+
+for p in $(ls patches -v)
+do
+	git apply patches/${p}
+done


### PR DESCRIPTION
Fixes #17
This is the official way for the upstream C code.
```c
extern int tinyfd_winUtf8; /* 0 (default MBCS) or 1 (UTF-8)*/
```