### PR TITLE
Also link to shell32 on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,5 +18,6 @@ fn main() {
         println!("cargo:rustc-link-lib=user32");
         println!("cargo:rustc-link-lib=comdlg32");
         println!("cargo:rustc-link-lib=ole32");
+        println!("cargo:rustc-link-lib=shell32");
     }
 }


### PR DESCRIPTION
Otherwise linker fails with
```
  = note: S:\Rust-target\debug\deps\libtinyfiledialogs-063ab3c866836036.rlib(tinyfiledialogs.o): In function `tinyfd_selectFolderDialogW':
          D:\Users\nabijaczleweli\.cargo\registry\src\github.com-1ecc6299db9ec823\tinyfiledialogs-3.3.5/libtinyfiledialogs/tinyfiledialogs.c:1776: undefined reference to `__imp_SHBrowseForFolderW'
          D:\Users\nabijaczleweli\.cargo\registry\src\github.com-1ecc6299db9ec823\tinyfiledialogs-3.3.5/libtinyfiledialogs/tinyfiledialogs.c:1779: undefined reference to `__imp_SHGetPathFromIDListW'
          S:\Rust-target\debug\deps\libtinyfiledialogs-063ab3c866836036.rlib(tinyfiledialogs.o): In function `selectFolderDialogWinGuiA':
          D:\Users\nabijaczleweli\.cargo\registry\src\github.com-1ecc6299db9ec823\tinyfiledialogs-3.3.5/libtinyfiledialogs/tinyfiledialogs.c:2250: undefined reference to `__imp_SHBrowseForFolderA'
          D:\Users\nabijaczleweli\.cargo\registry\src\github.com-1ecc6299db9ec823\tinyfiledialogs-3.3.5/libtinyfiledialogs/tinyfiledialogs.c:2253: undefined reference to `__imp_SHGetPathFromIDListA'
```

On my MSYS2 system