### PR TITLE
Don't link to shcore on windows-gnu targets

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
+  - TARGET: x86_64-pc-windows-gnu
 
 platform:
   - x64

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,8 @@ fn main() {
         println!("cargo:rustc-link-lib=comdlg32");
         println!("cargo:rustc-link-lib=ole32");
         println!("cargo:rustc-link-lib=shell32");
-        println!("cargo:rustc-link-lib=shcore");
+        if !target.ends_with("pc-windows-gnu") {
+            println!("cargo:rustc-link-lib=shcore");
+        }
     }
 }


### PR DESCRIPTION
Fixes #28 

Tested successfully on `x86_64-pc-windows-gnu` and `i686-pc-windows-gnu`.