### PR TITLE
Disable HIDPI for Windows GNU

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ use std::env;
 fn main() {
     let target = env::var("TARGET").unwrap();
 
-    let windows_hidpi = if cfg!(feature = "windows-hidpi") {
+    let windows_hidpi = if cfg!(feature = "windows-hidpi") & !target.ends_with("pc-windows-gnu") {
         "USE_WINDOWS_HIDPI"
     }else {
         "NO_WINDOWS_HIDPI"


### PR DESCRIPTION
Seems like HIDPI breaks builds with GCC installed through mingw and sometimes on WSL too. It's not a great fix but at least this lets us windows-gnu users build the library. Works in a quick test program but I don't even really know what HiDPI is so I have no idea if this is the right fix.

Possibly fixes #42 (and fixes my issue...)